### PR TITLE
Update: use faster closeNow()

### DIFF
--- a/windows/RNCloseButton/RNCloseButton.cpp
+++ b/windows/RNCloseButton/RNCloseButton.cpp
@@ -47,7 +47,16 @@ namespace winrt::RNCloseButton
   }
 
   void RNCloseButton::closeNow() noexcept {
-    Window::Current().Close();
+    HWND hwnd = getHwnd();
+    if (!hwnd)
+      return;
+    // Find the top-level owner (handles modals and nested windows)
+    HWND rootHwnd = GetAncestor(hwnd, GA_ROOTOWNER);
+    if (!rootHwnd)
+      rootHwnd = hwnd;
+    // Post the close message to the main window, not the modal
+    PostMessage(rootHwnd, WM_CLOSE, 0, 0);
+
   }
 
 } // namespace winrt::RNCloseButton


### PR DESCRIPTION
Resolves https://github.com/jihoobyeon/react-native-close-button/issues/1

If you see any problems with it or would rather it not completely replace the existing closeNow() please let me know.

Thank you,
Kyle